### PR TITLE
Fix Availability values to meet latest google merchant requirements

### DIFF
--- a/src/Product/Availability/Availability.php
+++ b/src/Product/Availability/Availability.php
@@ -4,9 +4,9 @@ namespace Vitalybaev\GoogleMerchant\Product\Availability;
 
 class Availability
 {
-    const IN_STOCK = 'in_stock';
+    const IN_STOCK = 'in stock';
 
-    const OUT_OF_STOCK = 'out_of_stock';
+    const OUT_OF_STOCK = 'out of stock';
 
     const PREORDER = 'preorder';
 }


### PR DESCRIPTION
Takes errors from google merchant while validating new feeds. Changing "in_stock" to "in stock" solve the problem.