### PR TITLE
non-printable characters in setAttribute param for setAdditionalImage

### DIFF
--- a/src/Product.php
+++ b/src/Product.php
@@ -126,7 +126,7 @@ class Product
      */
     public function setAdditionalImage($imageUrl)
     {
-        $this->setAttribute('additional_​image_​link', $imageUrl, true);
+        $this->setAttribute('additional_image_link', $imageUrl, true);
         return $this;
     }
 


### PR DESCRIPTION
additional_​image_​link

After the second underscore there is a non-printable character which borks the XML generation process.

You can test this be searching `src/Product.php` for "image_link" and notice that "additional_image_link is not highlighted. This one drove me nuts