### PR TITLE
Adding availability and expiration date

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,8 @@
     "psr-4": {
       "Vitalybaev\\GoogleMerchant\\": "src/"
     }
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^9.5"
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="tests/bootstrap.php">
-    <testsuites>
-        <testsuite name="phpbu">
-            <directory>tests/feed</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+>
+  <coverage>
+    <include>
+      <directory>src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="phpbu">
+      <directory>tests/feed</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Product.php
+++ b/src/Product.php
@@ -134,6 +134,32 @@ class Product
     }
 
     /**
+     * Sets availability date of the product. Only relevant if availability is set to 'preorder'.
+     *
+     * @param $availabilityDate
+     *
+     * @return $this
+     */
+    public function setAvailabilityDate($availabilityDate)
+    {
+        $this->setAttribute('availability_date', $availabilityDate, false);
+        return $this;
+    }
+
+    /**
+     * Sets the expiration date of the product.
+     *
+     * @param $expirationDate
+     *
+     * @return $this
+     */
+    public function setExpirationDate($expirationDate)
+    {
+        $this->setAttribute('expiration_date', $expirationDate, false);
+        return $this;
+    }
+
+    /**
      * Sets price of the product.
      *
      * @param string $price

--- a/tests/feed/ProductTest.php
+++ b/tests/feed/ProductTest.php
@@ -95,6 +95,34 @@ class ProductTest extends TestCase
         ], $product->getXmlStructure(static::PRODUCT_NAMESPACE));
     }
 
+    public function testProductSetsAvailabilityDate()
+    {
+        $date = '2021-04-01';
+
+        $product = new Product();
+        $product->setAvailabilityDate($date);
+
+        $this->assertEquals([
+            'item' => [
+                ['name' => "{http://base.google.com/ns/1.0}availability_date", "value" => $date],
+            ],
+        ], $product->getXmlStructure(static::PRODUCT_NAMESPACE));
+    }
+
+    public function testProductSetsExpirationDate()
+    {
+        $date = '2021-05-01';
+
+        $product = new Product();
+        $product->setExpirationDate($date);
+
+        $this->assertEquals([
+            'item' => [
+                ['name' => "{http://base.google.com/ns/1.0}expiration_date", "value" => $date],
+            ],
+        ], $product->getXmlStructure(static::PRODUCT_NAMESPACE));
+    }
+
     /**
      * Tests setting Id to product.
      */


### PR DESCRIPTION
Adding setters for [availability date](https://support.google.com/merchants/answer/6324470) and [expiration date](https://support.google.com/merchants/answer/6324499). Additionally adding the dev requirement `phpunit` as I stumbled across this when wanting write some tests.