### PR TITLE
feat: modified availability props to respect google contract

### DIFF
--- a/src/Product/Availability/Availability.php
+++ b/src/Product/Availability/Availability.php
@@ -4,9 +4,9 @@ namespace Vitalybaev\GoogleMerchant\Product\Availability;
 
 class Availability
 {
-    const IN_STOCK = 'in stock';
+    const IN_STOCK = 'in_stock';
 
-    const OUT_OF_STOCK = 'out of stock';
+    const OUT_OF_STOCK = 'out_of_stock';
 
     const PREORDER = 'preorder';
     


### PR DESCRIPTION
As commented in this [issue ](https://github.com/vitalybaev/php-google-merchant-feed/issues/15)
and checking the doc of google [google](https://support.google.com/merchants/answer/3061198?hl=en#) is needed to pass availability with underscores instead of spaces.
